### PR TITLE
Remove README section about the `--kind` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,23 +72,6 @@ postgres v0.10.2 (file:///Volumes/git/rust/rust-postgres)
         └── num v0.1.29 (*)
 ```
 
-Output can be switched to development or build dependencies with the `--kind`
-or `-k` flag:
-
-```
-$ cargo tree -k build
-postgres v0.10.2 (file:///Volumes/git/rust/rust-postgres)
-└── phf_codegen v0.7.9
-    ├── phf_generator v0.7.9
-    │   ├── phf_shared v0.7.9
-    │   └── rand v0.3.12
-    │       ├── advapi32-sys v0.1.2
-    │       │   └── winapi v0.2.5
-    │       ├── libc v0.2.4
-    │       └── winapi v0.2.5 (*)
-    └── phf_shared v0.7.9 (*)
-```
-
 `cargo tree` can also operate in an "inverse" mode where the dependency tree is
 walked backwards. This is most often useful when trying to determine where
 a certain crate is coming from. The `--package` or `-p` flag selects the crate


### PR DESCRIPTION
This flag was removed in commit d1fa3a657eae0c3713bfff3817cff5dca3f26b3e