### PR TITLE
Adds support for cargo workspaces, uses Cargo.toml from package given by --package

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,12 @@ fn real_main(args: Args, config: &mut Config) -> CliResult {
         &args.unstable_flags,
     )?;
 
-    let workspace = workspace(config, args.manifest_path)?;
+    let package = args.package.clone();
+    let manifest_path = args.manifest_path.or_else(|| {
+        Some(config.cwd().join(package?).join("Cargo.toml"))
+    });
+
+    let workspace = workspace(config, manifest_path)?;
     let package = workspace.current()?;
     let mut registry = registry(config, &package)?;
     let (packages, resolve) = resolve(


### PR DESCRIPTION
I'm definitely not familiar with cargo's API, so this is probably the wrong approach. I noticed that this crate didn't work in a cargo workspace by `-p sub-package-name` like other cargo commands tend to (like doc).

Maybe I also missed something completely, and this was already supported in a different way.