### PR TITLE
Expose errors encountered while calling rustc --print=cfg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ fn get_cfgs(rustc: &Rustc, target: &Option<String>) -> CargoResult<Option<Vec<Cf
 
     let output = match process.exec_with_output() {
         Ok(output) => output,
-        Err(_) => return Ok(None),
+        Err(e) => return Err(e),
     };
     let output = str::from_utf8(&output.stdout).unwrap();
     let lines = output.lines();


### PR DESCRIPTION
This will resolve #16.

When errors were returned by the rustc process call, they were disregarded and a None was returned, allowing `real_main` to continue with no configuration. By returning `Err(e)` instead of `None`, execution of `real_main` returns early and cargo exits and reports the rustc error on src/main.rs:178.

Providing an invalid target name like `cargo tree --target foo` would result in the dependency tree being displayed whereas the expected behavior is that we would encounter an error message similar to that presented by rustc. This commit results in the expected behavior.

The question comes down to whether or not the following error is deemed to be acceptable in this scenario. The output is just the error from ProcessBuilder, which doesn't make the problem immediately apparent (not to mention the rustc help message is misleading), however the problem **is** described on the third line of output, so an argument could be made that this is sufficient.

```
$ cargo tree --target foo
error: process didn't exit successfully: `rustc --print=cfg --target foo` (exit code: 1)
--- stderr
error: Error loading target specification: Could not find specification for target "foo"
  |
  = help: Use `--print target-list` for a list of built-in targets
```

Let me know what your thoughts are- if you'd like this to report a more concise error, let me know and I can update the PR.