### PR TITLE
More detailed message when a dependency isn't found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -265,11 +265,11 @@ fn real_main(args: Args, config: &mut Config) -> CliResult {
     if args.duplicates {
         let dups = find_duplicates(&graph);
         for dup in &dups {
-            print_tree(dup, &graph, &format, direction, symbols, prefix, args.all);
+            print_tree(dup, &graph, &format, direction, symbols, prefix, args.all)?;
             println!();
         }
     } else {
-        print_tree(root, &graph, &format, direction, symbols, prefix, args.all);
+        print_tree(root, &graph, &format, direction, symbols, prefix, args.all)?;
     }
 
     Ok(())
@@ -432,12 +432,12 @@ fn print_tree<'a>(
     symbols: &Symbols,
     prefix: Prefix,
     all: bool,
-) {
+) -> CargoResult<()> {
     let mut visited_deps = HashSet::new();
     let mut levels_continue = vec![];
 
     let package = graph.nodes.get(package)
-      .expect(&format!("package {} not found, try specifying an explicit --target", package));
+        .ok_or(failure::err_msg(format!("package {} not found, try specifying an explicit --target", package)))?;
     let node = &graph.graph[*package];
     print_dependency(
         node,
@@ -450,6 +450,7 @@ fn print_tree<'a>(
         prefix,
         all,
     );
+    Ok(())
 }
 
 fn print_dependency<'a>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -436,7 +436,9 @@ fn print_tree<'a>(
     let mut visited_deps = HashSet::new();
     let mut levels_continue = vec![];
 
-    let node = &graph.graph[graph.nodes[&package]];
+    let package = graph.nodes.get(package)
+      .expect(&format!("package {} not found, try specifying an explicit --target", package));
+    let node = &graph.graph[*package];
     print_dependency(
         node,
         &graph,


### PR DESCRIPTION
This adds a better error message for https://github.com/sfackler/cargo-tree/issues/44, e.g.

```
$  cargo tree -p openssl -i
thread 'main' panicked at 'package openssl v0.10.15 not found, try specifying an explicit --target', libcore/option.rs:1008:5
```
