### PR TITLE
Document OpenSSL and add Linux command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ in a tree-like format.
 Requirements: `cmake` and `openssl`.
 
 * macOS (via [homebrew](http://brew.sh/)): `brew install cmake openssl`
-* Debian/Ubuntu: `apt install cmake libssl-dev`
+* Debian/Ubuntu: `apt install cmake libssl-dev pkg-config`
 
 Install it with Cargo:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 `cargo tree` is a Cargo subcommand that visualizes a crate's dependency graph
 in a tree-like format.
 
-Requirements: `cmake`.  OSX users can install via [homebrew](http://brew.sh/): `brew install cmake` .
+Requirements: `cmake` and `openssl`.
+
+* macOS (via [homebrew](http://brew.sh/)): `brew install cmake openssl`
+* Debian/Ubuntu: `apt install cmake libssl-dev`
 
 Install it with Cargo:
 


### PR DESCRIPTION
Addresses #57 by documenting the dependency on OpenSSL. Also adds instructions for installing dependencies on Linux.