### PR TITLE
fix most clippy warnings

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -25,7 +25,7 @@ impl Pattern {
                 RawChunk::Argument("l") => Chunk::License,
                 RawChunk::Argument("r") => Chunk::Repository,
                 RawChunk::Argument(ref a) => {
-                    return Err(anyhow!("unsupported pattern `{}`", a).into());
+                    return Err(anyhow!("unsupported pattern `{}`", a));
                 }
                 RawChunk::Error(err) => return Err(anyhow!("{}", err)),
             };

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -15,7 +15,7 @@ pub struct Parser<'a> {
 impl<'a> Parser<'a> {
     pub fn new(s: &'a str) -> Parser<'a> {
         Parser {
-            s: s,
+            s,
             it: s.char_indices().peekable(),
         }
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -83,7 +83,7 @@ pub fn print(args: &Args, graph: &Graph) -> Result<(), Error> {
 }
 
 fn find_package<'a>(package: &str, graph: &'a Graph) -> Result<&'a PackageId, Error> {
-    let mut it = package.split(":");
+    let mut it = package.split(':');
     let name = it.next().unwrap();
     let version = it
         .next()
@@ -107,7 +107,7 @@ fn find_package<'a>(package: &str, graph: &'a Graph) -> Result<&'a PackageId, Er
         candidates.push(package);
     }
 
-    if candidates.len() == 0 {
+    if candidates.is_empty() {
         Err(anyhow!("no crates found for package `{}`", package))
     } else if candidates.len() > 1 {
         let specs = candidates


### PR DESCRIPTION
there are two 'too_many_arguments' warnings left.